### PR TITLE
#30: Removed incorrect docs

### DIFF
--- a/cmd/leases.go
+++ b/cmd/leases.go
@@ -91,7 +91,7 @@ var leasesCreateCmd = &cobra.Command{
 }
 
 var leasesEndCmd = &cobra.Command{
-	Use:   "end [Lease ID]",
+	Use:   "end",
 	Short: "Cause a lease to immediately expire",
 	Args:  cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {


### PR DESCRIPTION
See #30 

Fixed documentation on `dce leases end` to remove `id` parameter. The backend currently doesn't support this. 

Created [an issue](https://github.com/Optum/dce/issues/121) to introduce support for this.